### PR TITLE
Wizard :: login page shown if user is not logged in

### DIFF
--- a/jotform-wp-embed-fp-wrapper.js
+++ b/jotform-wp-embed-fp-wrapper.js
@@ -11,8 +11,12 @@ function JotFormFormPicker () {
         $this = this;
         if(!window.wizardCallBackInit) {
             XD.receiveMessage(function(message){
-                if(!message.data.closeModal) callback(message.data);
-                $this.closeWizard();
+                const data = { message }; 
+                if(data.closeModal) {
+                    $this.closeWizard();
+                } else if(data.id && data.title) {
+                    callback(message.data);
+                }
             }, 'https://www.jotform.com');
             window.wizardCallBackInit = true;
         }


### PR DESCRIPTION
[WordPress Embed Form Plugin: Form picker modal closes immediately when there is no Jotform session](https://www.jotform.com/answers/4735034-wordpress-embed-form-plugin-form-picker-modal-closes-immediately-when-there-is-no-jotform-session)

Login page doesn't disappear after the initialization